### PR TITLE
🚀 [Chore] DatePlace 관련 엔티티 재설계 및 ERD 수정

### DIFF
--- a/src/main/java/org/withtime/be/withtimebe/domain/date/entity/DatePlace.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/entity/DatePlace.java
@@ -2,6 +2,8 @@ package org.withtime.be.withtimebe.domain.date.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+
+import org.withtime.be.withtimebe.domain.date.entity.enums.PlaceType;
 import org.withtime.be.withtimebe.global.common.BaseEntity;
 
 @Entity
@@ -43,4 +45,8 @@ public class DatePlace extends BaseEntity {
 
     @Column(name = "lot_number_address")
     private String lotNumberAddress;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "place_type")
+    private PlaceType placeType;
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/entity/DatePlacePlaceCategory.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/entity/DatePlacePlaceCategory.java
@@ -2,7 +2,7 @@ package org.withtime.be.withtimebe.domain.date.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.withtime.be.withtimebe.domain.date.entity.enums.PlaceCategoryPriority;
+
 import org.withtime.be.withtimebe.global.common.BaseEntity;
 
 @Entity
@@ -25,8 +25,4 @@ public class DatePlacePlaceCategory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_category_id", nullable = false)
     private PlaceCategory placeCategory;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "place_category_priority", nullable = false)
-    private PlaceCategoryPriority placeCategoryPriority;
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/entity/PlaceCategory.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/entity/PlaceCategory.java
@@ -21,4 +21,13 @@ public class PlaceCategory extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "category_type", nullable = false)
     private PlaceCategoryType categoryType;
+
+    @Column(name = "code", nullable = false)
+    private String code;
+
+    @Column(name = "label", nullable = false)
+    private String label;
+
+    @Column(name = "description", nullable = false)
+    private String description;
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/entity/enums/PlaceCategoryPriority.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/entity/enums/PlaceCategoryPriority.java
@@ -1,7 +1,0 @@
-package org.withtime.be.withtimebe.domain.date.entity.enums;
-
-public enum PlaceCategoryPriority {
-    PRIMARY,
-    SECONDARY,
-    TERTIARY
-}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/entity/enums/PlaceCategoryType.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/entity/enums/PlaceCategoryType.java
@@ -1,80 +1,16 @@
 package org.withtime.be.withtimebe.domain.date.entity.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum PlaceCategoryType {
-
-    // 분위기
-    MOOD_ROMANTIC("로맨틱한", "연인과의 감성적인 분위기, 기념일, 야경 등"),
-    MOOD_WARM("감성적인", "따뜻하고 정서적인 공간, 잔잔한 대화에 어울림"),
-    MOOD_SERENE("조용한", "북카페, 전시, 자연 등 조용히 보내는 데이트"),
-    MOOD_CHILL("잔잔한", "부드럽고 편안한 분위기의 하루"),
-    MOOD_LIVELY("활기찬", "에너지 있고 북적이는 공간, 사람 구경 중심"),
-    MOOD_VIBRANT("감각적인", "트렌디하고 세련된 분위기의 장소"),
-    MOOD_DARK("어두운 조명", "조명 낮고 분위기 있는 공간 (바, 이자카야 등)"),
-    MOOD_PLAYFUL("유쾌한", "밝고 편한 분위기, 웃음 많은 데이트"),
-    MOOD_NOSTALGIC("레트로 감성", "복고풍 공간, 골목 탐방 중심"),
-    MOOD_COZY("아늑한", "작고 조용한 공간, 실내 중심 소규모 장소"),
-    MOOD_ANNIVERSARY("기념일 데이트", "특별한 날을 위한 코스 추천"),
-    MOOD_FIRST("첫 데이트 추천", "부담 적고 무난한 코스 구성"),
-
-    // 활동량
-    ACT_WALK("산책 중심", "가볍게 걷는 동선이 포함된 데이트"),
-    ACT_CHILL("편하게 쉬기", "오래 앉아 대화 중심, 카페 중심"),
-    ACT_MOVE("활동적인", "많이 걷고 체험하는 에너지 있는 구성"),
-    ACT_EXPLORE("탐험 중심", "새로운 장소를 여유 있게 탐방"),
-    ACT_PHOTO("사진 중심", "포토존이 많고 시각적으로 즐거운 장소"),
-    ACT_STAYSHORT("짧은 일정", "1~2시간 이내 짧은 데이트"),
-    ACT_LONGSTAY("긴 일정", "반나절~하루 일정의 여유 있는 구성"),
-    ACT_PAIR("같이 하는 체험", "두 사람이 함께 만드는 체험 (수공예 등)"),
-
-    // 장소 스타일
-    PLACE_ROOFTOP("루프탑 카페", "고층에서 도시 뷰를 볼 수 있는 공간"),
-    PLACE_VIEW("전망 좋은 곳", "시야가 트인 풍경, 시티뷰 등"),
-    PLACE_RIVER("한강 뷰", "수변/강 근처 코스"),
-    PLACE_MARKET("로컬 마켓", "플리마켓, 편집숍 구경"),
-    PLACE_NATURE("자연 가까운 곳", "숲, 강변, 공원 등 자연 동선 포함"),
-    PLACE_EXHIBIT("전시 공간", "미술관, 팝업 전시 등 문화적 체험 공간"),
-    PLACE_CRAFT("수공예 체험 공간", "만들기 중심 체험 장소"),
-    PLACE_THEATER("소극장 공연", "뮤지컬, 연극, 콘서트 등"),
-    PLACE_LIBRARY("북카페/책방", "조용한 분위기의 공간"),
-    PLACE_IZAKAYA("이자카야/펍", "조명 낮고 술과 식사를 함께할 수 있는 공간"),
-    PLACE_FUSION("퓨전 음식점", "이색적인 메뉴 중심 식당"),
-    PLACE_BRUNCH("브런치 카페", "오전/낮 중심 여유 있는 식사 장소"),
-    PLACE_DESSERT("디저트 카페", "음료+디저트 중심 공간"),
-    PLACE_KOREAN("한식 오마카세", "고급스러운 한국 식사 공간"),
-    PLACE_VINTAGE("레트로 골목", "복고풍 상점, 건물, 거리"),
-    PLACE_MALL("복합 공간 (몰)", "쇼핑, 카페, 산책 등 한 곳에서 가능한 공간"),
-
-    // 상황 & 시간대 & 날씨
-    TIME_BRUNCH("브런치 데이트", "오전 데이트 중심"),
-    TIME_SUNSET("노을 보기 좋은", "5~7시 중심 타이밍"),
-    TIME_EVENING("저녁 데이트", "저녁 식사 중심 또는 조명 활용 코스"),
-    WEATHER_HOT("더운 날 추천", "실내 위주 동선 제안"),
-    WEATHER_RAINY("비 오는 날 추천", "실내만으로 구성되는 코스"),
-    WEATHER_COLD("추운 날 추천", "따뜻하고 실내 위주 공간");
+    MOOD("분위기"),
+    ACTIVITY_TYPE("활동량"),
+    PLACE_STYLE("장소 스타일"),
+    CONTEXTUAL_CONDITION("상황/시간대/날씨"),
+    ;
 
     private final String label;
-    private final String detail;
-
-    PlaceCategoryType(String label, String detail) {
-        this.label = label;
-        this.detail = detail;
-    }
-
-    public String getLabel() {
-        return label;
-    }
-
-    public String getDetail() {
-        return detail;
-    }
-
-    public static PlaceCategoryType fromLabel(String label) {
-        for (PlaceCategoryType type : values()) {
-            if (type.label.equals(label)) {
-                return type;
-            }
-        }
-        // 차후 공통 익셉션으로 처리
-        throw new IllegalArgumentException("해당 라벨로 태그를 찾을 수 없습니다: " + label);
-    }
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/entity/enums/PlaceType.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/entity/enums/PlaceType.java
@@ -1,0 +1,16 @@
+package org.withtime.be.withtimebe.domain.date.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PlaceType {
+	TIME_EAT("식사", "식사 위주 장소"),
+	TIME_SEE("구경", "구경 위주 장소"),
+	TIME_CAFE("카페", "카페 위주 장소"),
+	;
+
+	private final String label;
+	private final String description;
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #24 

## 📌 개요
- 키워드 및 장소 유형 설계가 완료되었습니다.
  - https://www.notion.so/219e4447020b806abb0cff5df522538f

- 장소에 붙는 키워드는 4가지(분위기 / 활동량 / 장소 스타일 / 상황&시간대) 로 분류가 됩니다.

- 장소 유형은 3가지(식사 / 구경 / 카페) 로 분류가 됩니다.

## 🔁 변경 사항 
1. DatePlace에 PlaceType 필드를 추가해 어떤 유형의 장소인지 판별하도록 하였습니다.

2. PlaceCategory 엔티티에 키워드 관련 정보를 모두 담아, 차후 유지보수와 확장에 유리하도록 변경하였습니다.

3. PlaceCategoryType은 PlaceCategory가 4가지 대분류 중 어디에 속하는지를 의미하는 필드로 변경되었습니다.

## 📸 스크린샷 (Optional)
![place_category_update](https://github.com/user-attachments/assets/dc960109-4c2f-46ab-9e67-e6006ef035af)

- 요약
![image](https://github.com/user-attachments/assets/3aeef751-280e-4d0b-8870-9a253cde654a)



## 👀 기타 더 이야기해볼 점 (Optional)


## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
