### PR TITLE
🐛 [FIX] 중기 예보 데이터 파싱 로직 수정

### DIFF
--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/data/utils/WeatherDataParser.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/data/utils/WeatherDataParser.java
@@ -188,17 +188,21 @@ public class WeatherDataParser {
                 for (String line : lines) {
                     if (line.trim().isEmpty() || line.startsWith("#")) continue;
 
-                    String[] parts = line.trim().split("\\s+");
+                    String[] parts = parseLineWithQuotes(line.trim());
+
                     if (parts.length >= 11) {
                         MediumTermLandData landData = new MediumTermLandData(
                                 parts[1],  // TM_FC
                                 parts[2],  // TM_EF
                                 parts[6],  // SKY
-                                parts[10]  // RN_ST
+                                parts[10]  // RN_ST (올바른 인덱스)
                         );
 
                         String key = parts[1] + "_" + parts[2];
                         result.put(key, landData);
+
+                        log.debug("중기 육상예보 라인 파싱: key={}, sky={}, rnSt={}",
+                                key, parts[6], parts[10]);
                     }
                 }
             }
@@ -208,6 +212,48 @@ public class WeatherDataParser {
 
         log.debug("중기 육상예보 파싱 완료: {} 건", result.size());
         return result;
+    }
+
+    /**
+     * 띄어쓰기 문자열을 고려하여 라인을 파싱
+     */
+    private String[] parseLineWithQuotes(String line) {
+        List<String> parts = new ArrayList<>();
+        StringBuilder currentPart = new StringBuilder();
+        boolean inQuotes = false;
+
+        String[] tokens = line.split("\\s+");
+
+        for (String token : tokens) {
+            if (token.startsWith("\"") && token.endsWith("\"") && token.length() > 1) {
+                // 하나의 토큰이 완전한 쌍따옴표 문자열인 경우
+                parts.add(token.substring(1, token.length() - 1)); // 쌍따옴표 제거
+            } else if (token.startsWith("\"")) {
+                // 쌍따옴표 시작
+                inQuotes = true;
+                currentPart.append(token.substring(1)); // 시작 쌍따옴표 제거
+            } else if (token.endsWith("\"") && inQuotes) {
+                // 쌍따옴표 끝
+                if (currentPart.length() > 0) {
+                    currentPart.append(" ");
+                }
+                currentPart.append(token.substring(0, token.length() - 1)); // 끝 쌍따옴표 제거
+                parts.add(currentPart.toString());
+                currentPart.setLength(0);
+                inQuotes = false;
+            } else if (inQuotes) {
+                // 쌍따옴표 안의 중간 토큰
+                if (currentPart.length() > 0) {
+                    currentPart.append(" ");
+                }
+                currentPart.append(token);
+            } else {
+                // 일반 토큰
+                parts.add(token);
+            }
+        }
+
+        return parts.toArray(new String[0]);
     }
 
     private Map<String, MediumTermTempData> parseMediumTermTempData(String response) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #64 

## 📌 개요
현재 데이터가 
```
#START7777
# REG_ID TM_FC        TM_EF        MOD STN C SKY  PRE  CONF WF    RN_ST
11B00000 202507310600 202508040000 A02 109 2 WB01 WB00 없음 "맑음" 20
11B00000 202507310600 202508041200 A02 109 2 WB03 WB00 없음 "구름많음" 30
11B00000 202507310600 202508050000 A02 109 2 WB04 WB00 없음 "흐림" 40
11B00000 202507310600 202508051200 A02 109 2 WB04 WB09 없음 "흐리고 비" 70
11B00000 202507310600 202508060000 A02 109 2 WB04 WB09 없음 "흐리고 비" 80
11B00000 202507310600 202508061200 A02 109 2 WB04 WB09 없음 "흐리고 비" 80
11B00000 202507310600 202508070000 A02 109 2 WB04 WB00 없음 "흐림" 40
11B00000 202507310600 202508071200 A02 109 2 WB04 WB00 없음 "흐림" 40
11B00000 202507310600 202508080000 A01 109 2 WB04 WB00 없음 "흐림" 40
11B00000 202507310600 202508090000 A01 109 2 WB04 WB00 없음 "흐림" 40
11B00000 202507310600 202508100000 A01 109 2 WB04 WB00 없음 "흐림" 40
#7777END
```

이런식으로 오는데 


``` 
강수확률 파싱 불가능한 값: 비" -> null 반환
중기예보 데이터 불완전하여 스킵: key=202507310600_202508060000, pop=비", minTmp=26, maxTmp=33
중기예보 파싱 완료: regionId=1, 성공 6/11 건
```

이런식으로 "흐리고 비" 데이터일 경우
"흐리고" + "비"로 분리되어 인덱스가 하나씩 밀려나는 문제를 확인했습니다.

따라서 해당 "흐리고 비" 데이터를 하나의 토큰으로 처리하여 올바르게 파싱 로직 수정하였습니다.

## 🔁 변경 사항 

## 📸 스크린샷 (Optional)
<img width="1341" height="383" alt="image" src="https://github.com/user-attachments/assets/87a93e78-ba84-4739-8e8e-60ebf610db5a" />

정상적으로 파싱 성공


## 👀 기타 더 이야기해볼 점 (Optional)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
