### PR TITLE
✨ [Feat] 데이트 취향 테스트 API 구현

### DIFF
--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/controller/DatePreferenceController.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/controller/DatePreferenceController.java
@@ -2,6 +2,7 @@ package org.withtime.be.withtimebe.domain.date.preference.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.namul.api.payload.response.DefaultResponse;
@@ -40,6 +41,16 @@ public class DatePreferenceController {
     }
 
     @Operation(summary = "데이트 취향 테스트 API", description = "질문에 대한 답변으로 결과 생성하는 API 1, 2 둘 중 하나로 40개로 채워 배열 형태로 전송")
+    @ApiResponses({
+            @ApiResponse(responseCode = "COMMON200", description = "테스트에 성공했습니다."),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            다음과 같은 이유로 실패할 수 있습니다:
+                            - DATE_PREFERENCE400_1: 질문에 대한 형식이 잘못되었습니다.
+                            """
+            ),
+    })
     @PostMapping("/tests")
     public DefaultResponse<DatePreferenceResponseDTO.TestResult> test(@AuthenticatedMember Member member, @RequestBody DatePreferenceRequestDTO.Test request) {
         return DefaultResponse.ok(datePreferenceTestCommandService.test(member, request));

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/controller/DatePreferenceController.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/controller/DatePreferenceController.java
@@ -1,0 +1,38 @@
+package org.withtime.be.withtimebe.domain.date.preference.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.namul.api.payload.response.DefaultResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.withtime.be.withtimebe.domain.date.preference.converter.DatePreferenceConverter;
+import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceResponseDTO;
+import org.withtime.be.withtimebe.domain.date.preference.service.query.DatePreferenceDescriptionQueryService;
+import org.withtime.be.withtimebe.domain.date.preference.service.query.DatePreferenceQuestionQueryService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/dates/preferences")
+@Tag(name = "데이트 취향 테스트 API")
+public class DatePreferenceController {
+
+    private final DatePreferenceDescriptionQueryService datePreferenceDescriptionQueryService;
+    private final DatePreferenceQuestionQueryService datePreferenceQuestionQueryService;
+
+    @Operation(summary = "데이트 취향 조회 API", description = "데이트 취향 종류 조회")
+    @ApiResponse(responseCode = "COMMON200", description = "성공적으로 정보를 가져왔습니다.")
+    @GetMapping
+    public DefaultResponse<DatePreferenceResponseDTO.FindTypes> findTypes() {
+        return DefaultResponse.ok(DatePreferenceConverter.toFindTypes(datePreferenceDescriptionQueryService.findTypes()));
+    }
+
+    @Operation(summary = "데이트 취향 테스트 질문 조회 API", description = "데이트 취향 테스트에 사용되는 질문 조회하는 API")
+    @ApiResponse(responseCode = "COMMON200", description = "성공적으로 정보를 가져왔습니다.")
+    @GetMapping("/questions")
+    public DefaultResponse<DatePreferenceResponseDTO.FindQuestions> findQuestions() {
+        return DefaultResponse.ok(DatePreferenceConverter.toFindQuestions(datePreferenceQuestionQueryService.findQuestions()));
+    }
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/controller/DatePreferenceController.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/controller/DatePreferenceController.java
@@ -5,13 +5,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.namul.api.payload.response.DefaultResponse;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.withtime.be.withtimebe.domain.date.preference.converter.DatePreferenceConverter;
+import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceRequestDTO;
 import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceResponseDTO;
+import org.withtime.be.withtimebe.domain.date.preference.service.command.DatePreferenceTestCommandService;
 import org.withtime.be.withtimebe.domain.date.preference.service.query.DatePreferenceDescriptionQueryService;
 import org.withtime.be.withtimebe.domain.date.preference.service.query.DatePreferenceQuestionQueryService;
+import org.withtime.be.withtimebe.domain.member.entity.Member;
+import org.withtime.be.withtimebe.global.security.annotation.AuthenticatedMember;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,6 +21,7 @@ import org.withtime.be.withtimebe.domain.date.preference.service.query.DatePrefe
 @Tag(name = "데이트 취향 테스트 API")
 public class DatePreferenceController {
 
+    private final DatePreferenceTestCommandService datePreferenceTestCommandService;
     private final DatePreferenceDescriptionQueryService datePreferenceDescriptionQueryService;
     private final DatePreferenceQuestionQueryService datePreferenceQuestionQueryService;
 
@@ -35,4 +38,11 @@ public class DatePreferenceController {
     public DefaultResponse<DatePreferenceResponseDTO.FindQuestions> findQuestions() {
         return DefaultResponse.ok(DatePreferenceConverter.toFindQuestions(datePreferenceQuestionQueryService.findQuestions()));
     }
+
+    @Operation(summary = "데이트 취향 테스트 API", description = "질문에 대한 답변으로 결과 생성하는 API 1, 2 둘 중 하나로 40개로 채워 배열 형태로 전송")
+    @PostMapping("/tests")
+    public DefaultResponse<DatePreferenceResponseDTO.TestResult> test(@AuthenticatedMember Member member, @RequestBody DatePreferenceRequestDTO.Test request) {
+        return DefaultResponse.ok(datePreferenceTestCommandService.test(member, request));
+    }
+
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/converter/DatePreferenceConverter.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/converter/DatePreferenceConverter.java
@@ -1,0 +1,39 @@
+package org.withtime.be.withtimebe.domain.date.preference.converter;
+
+import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceResponseDTO;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceDescription;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceQuestion;
+
+import java.util.List;
+
+public class DatePreferenceConverter {
+    public static DatePreferenceResponseDTO.FindTypes toFindTypes(List<DatePreferenceDescription> datePreferenceDescriptions) {
+        return DatePreferenceResponseDTO.FindTypes.builder()
+                .types(datePreferenceDescriptions.stream().map(DatePreferenceConverter::toFindType).toList())
+                .size(datePreferenceDescriptions.size())
+                .build();
+    }
+
+    public static DatePreferenceResponseDTO.FindType toFindType(DatePreferenceDescription datePreferenceDescription) {
+        return DatePreferenceResponseDTO.FindType.builder()
+                .symbolicAnimal(datePreferenceDescription.getSymbolicAnimal())
+                .preferenceType(datePreferenceDescription.getPreferenceType())
+                .simpleDescription(datePreferenceDescription.getSimpleDescription())
+                .build();
+    }
+
+    public static DatePreferenceResponseDTO.FindQuestions toFindQuestions(List<DatePreferenceQuestion> datePreferenceQuestions) {
+        return DatePreferenceResponseDTO.FindQuestions.builder()
+                .questions(datePreferenceQuestions.stream().map(DatePreferenceConverter::toFindQuestion).toList())
+                .size(datePreferenceQuestions.size())
+                .build();
+    }
+
+    public static DatePreferenceResponseDTO.FindQuestion toFindQuestion(DatePreferenceQuestion datePreferenceQuestion) {
+        return DatePreferenceResponseDTO.FindQuestion.builder()
+                .question(datePreferenceQuestion.getQuestion())
+                .firstAnswer(datePreferenceQuestion.getFirstAnswer())
+                .secondAnswer(datePreferenceQuestion.getSecondAnswer())
+                .build();
+    }
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/converter/DatePreferenceConverter.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/converter/DatePreferenceConverter.java
@@ -2,7 +2,10 @@ package org.withtime.be.withtimebe.domain.date.preference.converter;
 
 import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceResponseDTO;
 import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceDescription;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferencePartDescription;
 import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceQuestion;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceTestResult;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferenceType;
 
 import java.util.List;
 
@@ -34,6 +37,59 @@ public class DatePreferenceConverter {
                 .question(datePreferenceQuestion.getQuestion())
                 .firstAnswer(datePreferenceQuestion.getFirstAnswer())
                 .secondAnswer(datePreferenceQuestion.getSecondAnswer())
+                .build();
+    }
+
+    public static DatePreferenceResponseDTO.TestResult toTestResult(DatePreferenceTestResult datePreferenceTestResult,
+                                                                    DatePreferenceDescription datePreferenceDescription,
+                                                                    List<DatePreferencePartDescription> datePreferencePartDescriptions) {
+        return DatePreferenceResponseDTO.TestResult.builder()
+                .preferenceType(datePreferenceTestResult.getPreferenceType())
+                .aPercentage(datePreferenceTestResult.getAPercentage())
+                .bPercentage(datePreferenceTestResult.getBPercentage())
+                .cPercentage(datePreferenceTestResult.getCPercentage())
+                .dPercentage(datePreferenceTestResult.getDPercentage())
+                .typeDescription(datePreferenceDescription == null ? null : DatePreferenceConverter.toTypeDescription(datePreferenceDescription))
+                .partTypeDescriptions(datePreferencePartDescriptions == null || datePreferencePartDescriptions.isEmpty() ? null : DatePreferenceConverter.toPartTypeDescriptions(datePreferencePartDescriptions))
+                .build();
+    }
+
+    public static DatePreferenceTestResult toDatePreferenceTestResult(PreferenceType preferenceType,
+                                                                       Double aPercentage,
+                                                                       Double bPercentage,
+                                                                       Double cPercentage,
+                                                                       Double dPercentage) {
+        return DatePreferenceTestResult.builder()
+                .preferenceType(preferenceType)
+                .aPercentage(aPercentage)
+                .bPercentage(bPercentage)
+                .cPercentage(cPercentage)
+                .dPercentage(dPercentage)
+                .build();
+    }
+
+    public static DatePreferenceResponseDTO.TypeDescription toTypeDescription(DatePreferenceDescription datePreferenceDescription) {
+        return DatePreferenceResponseDTO.TypeDescription.builder()
+                .symbolicAnimal(datePreferenceDescription.getSymbolicAnimal())
+                .preferenceType(datePreferenceDescription.getPreferenceType())
+                .simpleDescription(datePreferenceDescription.getSimpleDescription())
+                .analysis(datePreferenceDescription.getAnalysis())
+                .build();
+    }
+
+    public static DatePreferenceResponseDTO.PartTypeDescriptions toPartTypeDescriptions(List<DatePreferencePartDescription> descriptions) {
+        return DatePreferenceResponseDTO.PartTypeDescriptions.builder()
+                .types(descriptions.stream().map(DatePreferenceConverter::toPartTypeDescription).toList())
+                .size(descriptions.size())
+                .build();
+    }
+
+    public static DatePreferenceResponseDTO.PartTypeDescription toPartTypeDescription(DatePreferencePartDescription description) {
+        return DatePreferenceResponseDTO.PartTypeDescription.builder()
+                .typeInitial(description.getPreferencePartType())
+                .type(description.getType())
+                .typeEng(description.getTypeEng())
+                .description(description.getDescription())
                 .build();
     }
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/dto/DatePreferenceRequestDTO.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/dto/DatePreferenceRequestDTO.java
@@ -1,0 +1,24 @@
+package org.withtime.be.withtimebe.domain.date.preference.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record DatePreferenceRequestDTO() {
+    public record Test(
+            @Schema(
+                    description = "1 또는 2 중 하나의 값으로 이루어진 40개의 답변",
+                    example = """
+                    [
+                        1, 1, 1, 1, 2, 2, 2, 2, 2, 2,
+                        1, 1, 1, 1, 1, 1, 2, 2, 2, 2,
+                        1, 1, 1, 1, 2, 2, 2, 2, 2, 2,
+                        1, 1, 1, 1, 1, 1, 2, 2, 2, 2
+                    ]
+                    """
+            )
+            List<Integer> answers
+    ) {
+
+    }
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/dto/DatePreferenceResponseDTO.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/dto/DatePreferenceResponseDTO.java
@@ -1,6 +1,7 @@
 package org.withtime.be.withtimebe.domain.date.preference.dto;
 
 import lombok.Builder;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferencePartType;
 import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferenceType;
 
 import java.util.List;
@@ -41,5 +42,45 @@ public record DatePreferenceResponseDTO() {
 
     }
 
+    @Builder
+    public record TestResult(
+            PreferenceType preferenceType,
+            Double aPercentage,
+            Double bPercentage,
+            Double cPercentage,
+            Double dPercentage,
+            TypeDescription typeDescription,
+            PartTypeDescriptions partTypeDescriptions
+    ) {
+
+    }
+
+    @Builder
+    public record TypeDescription(
+            String symbolicAnimal,
+            PreferenceType preferenceType,
+            String simpleDescription,
+            String analysis
+    ) {
+
+    }
+
+    @Builder
+    public record PartTypeDescriptions(
+            List<PartTypeDescription> types,
+            Integer size
+    ) {
+
+    }
+
+    @Builder
+    public record PartTypeDescription(
+            PreferencePartType typeInitial,
+            String typeEng,
+            String type,
+            String description
+    ) {
+
+    }
 
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/dto/DatePreferenceResponseDTO.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/dto/DatePreferenceResponseDTO.java
@@ -1,0 +1,45 @@
+package org.withtime.be.withtimebe.domain.date.preference.dto;
+
+import lombok.Builder;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferenceType;
+
+import java.util.List;
+
+public record DatePreferenceResponseDTO() {
+
+    @Builder
+    public record FindTypes(
+            List<FindType> types,
+            Integer size
+    ) {
+
+    }
+
+    @Builder
+    public record FindType(
+            String symbolicAnimal,
+            PreferenceType preferenceType,
+            String simpleDescription
+    ) {
+
+    }
+
+    @Builder
+    public record FindQuestions(
+            List<FindQuestion> questions,
+            Integer size
+    ) {
+
+    }
+
+    @Builder
+    public record FindQuestion(
+            String question,
+            String firstAnswer,
+            String secondAnswer
+    ) {
+
+    }
+
+
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceDescription.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceDescription.java
@@ -1,0 +1,32 @@
+package org.withtime.be.withtimebe.domain.date.preference.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferenceType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "date_preference_description")
+public class DatePreferenceDescription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "date_preference_description_id")
+    private Long id;
+
+    @Column(name = "symbolic_animal")
+    private String symbolicAnimal;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "preference_type", unique = true)
+    private PreferenceType preferenceType;
+
+    @Column(name = "simple_description")
+    private String simpleDescription;
+
+    @Column(name = "analysis", columnDefinition = "TEXT")
+    private String analysis;
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceDescriptionKeyword.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceDescriptionKeyword.java
@@ -1,0 +1,25 @@
+package org.withtime.be.withtimebe.domain.date.preference.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "date_preference_description_keyword")
+public class DatePreferenceDescriptionKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "date_preference_description")
+    private DatePreferenceDescription datePreferenceDescription;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "date_preference_keyword")
+    private DatePreferenceKeyword datePreferenceKeyword;
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceDescriptionKeyword.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceDescriptionKeyword.java
@@ -13,6 +13,7 @@ public class DatePreferenceDescriptionKeyword {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "date_preference_description_keyword_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceKeyword.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceKeyword.java
@@ -1,0 +1,22 @@
+package org.withtime.be.withtimebe.domain.date.preference.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "date_preference_keyword")
+public class DatePreferenceKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "date_preference_keyword_id")
+    private Long id;
+
+    @Column(name = "keyword")
+    private String keyword;
+
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferencePartDescription.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferencePartDescription.java
@@ -1,0 +1,32 @@
+package org.withtime.be.withtimebe.domain.date.preference.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferencePartType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "date_preference_part_description")
+public class DatePreferencePartDescription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "date_preference_description_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "preference_part_type", unique = true)
+    private PreferencePartType preferencePartType;
+
+    @Column(name = "type_eng")
+    private String typeEng;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "description")
+    private String description;
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferencePartDescription.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferencePartDescription.java
@@ -14,7 +14,7 @@ public class DatePreferencePartDescription {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "date_preference_description_id")
+    @Column(name = "date_preference_part_description_id")
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceQuestion.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceQuestion.java
@@ -1,0 +1,27 @@
+package org.withtime.be.withtimebe.domain.date.preference.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "date_preference_question")
+public class DatePreferenceQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "date_preference_question")
+    private Long id;
+
+    @Column(name = "question")
+    private String question;
+
+    @Column(name = "first_answer")
+    private String firstAnswer;
+
+    @Column(name = "second_answer")
+    private String secondAnswer;
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceQuestion.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceQuestion.java
@@ -13,7 +13,7 @@ public class DatePreferenceQuestion {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "date_preference_question")
+    @Column(name = "date_preference_question_id")
     private Long id;
 
     @Column(name = "question")

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceTestResult.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceTestResult.java
@@ -39,4 +39,8 @@ public class DatePreferenceTestResult extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    public void mappingMember(Member member) {
+        this.member = member;
+    }
+
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceTestResult.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/DatePreferenceTestResult.java
@@ -1,0 +1,42 @@
+package org.withtime.be.withtimebe.domain.date.preference.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferenceType;
+import org.withtime.be.withtimebe.domain.member.entity.Member;
+import org.withtime.be.withtimebe.global.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "date_preference_test_result")
+public class DatePreferenceTestResult extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "date_preference_test_result_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "preferencePartType")
+    private PreferenceType preferenceType;
+
+    @Column(name = "a_percentage")
+    private Double aPercentage;
+
+    @Column(name = "b_percentage")
+    private Double bPercentage;
+
+    @Column(name = "c_percentage")
+    private Double cPercentage;
+
+    @Column(name = "d_percentage")
+    private Double dPercentage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/enums/PreferencePartType.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/enums/PreferencePartType.java
@@ -1,0 +1,8 @@
+package org.withtime.be.withtimebe.domain.date.preference.entity.enums;
+
+public enum PreferencePartType {
+    S,F,
+    A,C,
+    M,P,
+    O,E
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/enums/PreferenceType.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/entity/enums/PreferenceType.java
@@ -1,0 +1,20 @@
+package org.withtime.be.withtimebe.domain.date.preference.entity.enums;
+
+public enum PreferenceType {
+    SAME,
+    SAMO,
+    SAPE,
+    SAPO,
+    SCME,
+    SCMO,
+    SCPE,
+    SCPO,
+    FAME,
+    FAMO,
+    FAPE,
+    FAPO,
+    FCME,
+    FCMO,
+    FCPE,
+    FCPO
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceDescriptionKeywordRepository.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceDescriptionKeywordRepository.java
@@ -1,0 +1,7 @@
+package org.withtime.be.withtimebe.domain.date.preference.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceDescriptionKeyword;
+
+public interface DatePreferenceDescriptionKeywordRepository extends JpaRepository<DatePreferenceDescriptionKeyword, Long> {
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceDescriptionRepository.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceDescriptionRepository.java
@@ -2,6 +2,10 @@ package org.withtime.be.withtimebe.domain.date.preference.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceDescription;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferenceType;
+
+import java.util.Optional;
 
 public interface DatePreferenceDescriptionRepository extends JpaRepository<DatePreferenceDescription, Long> {
+    Optional<DatePreferenceDescription> findByPreferenceType(PreferenceType preferenceType);
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceDescriptionRepository.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceDescriptionRepository.java
@@ -1,0 +1,7 @@
+package org.withtime.be.withtimebe.domain.date.preference.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceDescription;
+
+public interface DatePreferenceDescriptionRepository extends JpaRepository<DatePreferenceDescription, Long> {
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceKeywordRepository.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceKeywordRepository.java
@@ -1,0 +1,7 @@
+package org.withtime.be.withtimebe.domain.date.preference.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceKeyword;
+
+public interface DatePreferenceKeywordRepository extends JpaRepository<DatePreferenceKeyword, Long> {
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferencePartDescriptionRepository.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferencePartDescriptionRepository.java
@@ -2,6 +2,10 @@ package org.withtime.be.withtimebe.domain.date.preference.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferencePartDescription;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferencePartType;
+
+import java.util.Optional;
 
 public interface DatePreferencePartDescriptionRepository extends JpaRepository<DatePreferencePartDescription, Long> {
+    Optional<DatePreferencePartDescription> findByPreferencePartType(PreferencePartType preferencePartType);
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferencePartDescriptionRepository.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferencePartDescriptionRepository.java
@@ -1,0 +1,7 @@
+package org.withtime.be.withtimebe.domain.date.preference.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferencePartDescription;
+
+public interface DatePreferencePartDescriptionRepository extends JpaRepository<DatePreferencePartDescription, Long> {
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceQuestionRepository.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceQuestionRepository.java
@@ -1,0 +1,10 @@
+package org.withtime.be.withtimebe.domain.date.preference.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceQuestion;
+
+import java.util.List;
+
+public interface DatePreferenceQuestionRepository extends JpaRepository<DatePreferenceQuestion, Long> {
+    List<DatePreferenceQuestion> findAllByOrderByIdAsc();
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceTestResultRepository.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/DatePreferenceTestResultRepository.java
@@ -1,0 +1,7 @@
+package org.withtime.be.withtimebe.domain.date.preference.repository;
+
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceTestResult;
+
+public interface DatePreferenceTestResultRepository {
+    DatePreferenceTestResult save(DatePreferenceTestResult datePreferenceTestResult);
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/JpaDatePreferenceTestResultRepository.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/repository/JpaDatePreferenceTestResultRepository.java
@@ -1,0 +1,7 @@
+package org.withtime.be.withtimebe.domain.date.preference.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceTestResult;
+
+public interface JpaDatePreferenceTestResultRepository extends DatePreferenceTestResultRepository, JpaRepository<DatePreferenceTestResult, Long> {
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/command/DatePreferenceTestCommandService.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/command/DatePreferenceTestCommandService.java
@@ -1,0 +1,9 @@
+package org.withtime.be.withtimebe.domain.date.preference.service.command;
+
+import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceRequestDTO;
+import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceResponseDTO;
+import org.withtime.be.withtimebe.domain.member.entity.Member;
+
+public interface DatePreferenceTestCommandService {
+    DatePreferenceResponseDTO.TestResult test(Member member, DatePreferenceRequestDTO.Test request);
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/command/DatePreferenceTestCommandServiceImpl.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/command/DatePreferenceTestCommandServiceImpl.java
@@ -1,0 +1,70 @@
+package org.withtime.be.withtimebe.domain.date.preference.service.command;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.withtime.be.withtimebe.domain.date.preference.converter.DatePreferenceConverter;
+import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceRequestDTO;
+import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceResponseDTO;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferencePartDescription;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceTestResult;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferencePartType;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferenceType;
+import org.withtime.be.withtimebe.domain.date.preference.repository.DatePreferenceDescriptionRepository;
+import org.withtime.be.withtimebe.domain.date.preference.repository.DatePreferencePartDescriptionRepository;
+import org.withtime.be.withtimebe.domain.date.preference.repository.DatePreferenceQuestionRepository;
+import org.withtime.be.withtimebe.domain.date.preference.repository.DatePreferenceTestResultRepository;
+import org.withtime.be.withtimebe.domain.date.preference.util.DatePreferenceTestScoreCalculator;
+import org.withtime.be.withtimebe.domain.member.entity.Member;
+import org.withtime.be.withtimebe.global.error.code.DatePreferenceErrorCode;
+import org.withtime.be.withtimebe.global.error.exception.DatePreferenceException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DatePreferenceTestCommandServiceImpl implements DatePreferenceTestCommandService {
+
+    private final DatePreferenceDescriptionRepository datePreferenceDescriptionRepository;
+    private final DatePreferencePartDescriptionRepository datePreferencePartDescriptionRepository;
+    private final DatePreferenceTestResultRepository datePreferenceTestResultRepository;
+    private final DatePreferenceQuestionRepository datePreferenceQuestionRepository;
+    private final DatePreferenceTestScoreCalculator datePreferenceTestScoreCalculator;
+
+    @Override
+    public DatePreferenceResponseDTO.TestResult test(Member member, DatePreferenceRequestDTO.Test request) {
+        // valid 판단
+        if (!validateRequest(request)) {
+            throw new DatePreferenceException(DatePreferenceErrorCode.INVALID_ANSWERS);
+        }
+
+        // 점수 계산
+        DatePreferenceTestResult result = datePreferenceTestScoreCalculator.calculateTestScore(request);
+        result.mappingMember(member);
+
+        // 엔티티 저장 (로그)
+        datePreferenceTestResultRepository.save(result);
+
+        // 응답 생성
+        return buildResponse(result);
+    }
+
+    private boolean validateRequest(DatePreferenceRequestDTO.Test request) {
+        return datePreferenceQuestionRepository.count() == request.answers().size() && request.answers().stream().allMatch(value -> value >= 1 && value <= 2);
+    }
+
+    private DatePreferenceResponseDTO.TestResult buildResponse(DatePreferenceTestResult testResult) {
+        List<DatePreferencePartDescription> partDescriptionList = new ArrayList<>();
+        PreferenceType preferenceType = testResult.getPreferenceType();
+        for (int i = 0; i < 4; i++) {
+            PreferencePartType preferencePartType = PreferencePartType.valueOf(preferenceType.name().substring(i, i + 1));
+            datePreferencePartDescriptionRepository.findByPreferencePartType(preferencePartType).ifPresent(partDescriptionList::add);
+        }
+        return DatePreferenceConverter.toTestResult(
+                testResult,
+                datePreferenceDescriptionRepository.findByPreferenceType(preferenceType).orElse(null),
+                partDescriptionList
+        );
+    }
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/query/DatePreferenceDescriptionQueryService.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/query/DatePreferenceDescriptionQueryService.java
@@ -1,0 +1,11 @@
+package org.withtime.be.withtimebe.domain.date.preference.service.query;
+
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceDescription;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceQuestion;
+
+import java.util.List;
+
+public interface DatePreferenceDescriptionQueryService {
+
+    List<DatePreferenceDescription> findTypes();
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/query/DatePreferenceDescriptionQueryServiceImpl.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/query/DatePreferenceDescriptionQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package org.withtime.be.withtimebe.domain.date.preference.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceDescription;
+import org.withtime.be.withtimebe.domain.date.preference.repository.DatePreferenceDescriptionRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DatePreferenceDescriptionQueryServiceImpl implements DatePreferenceDescriptionQueryService {
+
+    private final DatePreferenceDescriptionRepository datePreferenceDescriptionRepository;
+
+    @Override
+    public List<DatePreferenceDescription> findTypes() {
+        return datePreferenceDescriptionRepository.findAll();
+    }
+
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/query/DatePreferenceQuestionQueryService.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/query/DatePreferenceQuestionQueryService.java
@@ -1,0 +1,9 @@
+package org.withtime.be.withtimebe.domain.date.preference.service.query;
+
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceQuestion;
+
+import java.util.List;
+
+public interface DatePreferenceQuestionQueryService {
+    List<DatePreferenceQuestion> findQuestions();
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/query/DatePreferenceQuestionQueryServiceImpl.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/service/query/DatePreferenceQuestionQueryServiceImpl.java
@@ -1,0 +1,20 @@
+package org.withtime.be.withtimebe.domain.date.preference.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceQuestion;
+import org.withtime.be.withtimebe.domain.date.preference.repository.DatePreferenceQuestionRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DatePreferenceQuestionQueryServiceImpl implements DatePreferenceQuestionQueryService {
+
+    private final DatePreferenceQuestionRepository datePreferenceQuestionRepository;
+
+    @Override
+    public List<DatePreferenceQuestion> findQuestions() {
+        return datePreferenceQuestionRepository.findAllByOrderByIdAsc();
+    }
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/util/DatePreferenceTestScoreCalculator.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/util/DatePreferenceTestScoreCalculator.java
@@ -1,0 +1,8 @@
+package org.withtime.be.withtimebe.domain.date.preference.util;
+
+import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceRequestDTO;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceTestResult;
+
+public interface DatePreferenceTestScoreCalculator {
+    DatePreferenceTestResult calculateTestScore(DatePreferenceRequestDTO.Test request);
+}

--- a/src/main/java/org/withtime/be/withtimebe/domain/date/preference/util/WeightBaseTestScoreCalculator.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/date/preference/util/WeightBaseTestScoreCalculator.java
@@ -1,0 +1,67 @@
+package org.withtime.be.withtimebe.domain.date.preference.util;
+
+import org.springframework.stereotype.Component;
+import org.withtime.be.withtimebe.domain.date.preference.converter.DatePreferenceConverter;
+import org.withtime.be.withtimebe.domain.date.preference.dto.DatePreferenceRequestDTO;
+import org.withtime.be.withtimebe.domain.date.preference.entity.DatePreferenceTestResult;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferencePartType;
+import org.withtime.be.withtimebe.domain.date.preference.entity.enums.PreferenceType;
+
+import java.util.List;
+
+@Component
+public class WeightBaseTestScoreCalculator implements DatePreferenceTestScoreCalculator {
+
+    private static final PreferencePartType[][] types = {
+            {PreferencePartType.S, PreferencePartType.F},
+            {PreferencePartType.A, PreferencePartType.C},
+            {PreferencePartType.M, PreferencePartType.P},
+            {PreferencePartType.E, PreferencePartType.O}
+    };
+
+    private static final double[] weights = {
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+    };
+
+    @Override
+    public DatePreferenceTestResult calculateTestScore(DatePreferenceRequestDTO.Test request) {
+        List<Integer> answers = request.answers(); // 정답 배열
+        int number = types.length; // PartType 개수
+        int size = answers.size() / number; // PartType 개수 별 정답 개수
+        Double[] percentages = new Double[number];
+        StringBuilder type = new StringBuilder();
+
+        // 계산
+        for (int i = 0; i < number ; i++) {
+            type.append(calculatePartType(answers, percentages, i * size, size));
+        }
+
+        return DatePreferenceConverter.toDatePreferenceTestResult(
+                PreferenceType.valueOf(type.toString()),
+                percentages[0],
+                percentages[1],
+                percentages[2],
+                percentages[3]
+        );
+    }
+
+    private String calculatePartType(List<Integer> list, Double[] percentages, int start, int size) {
+        double score = calculateScore(list, start, size);
+        int index = start / size;
+        percentages[index] = Math.floor((score - 1) * 1000) / 10;
+        return score < 1.5 ? types[index][0].name() : types[index][1].name();
+    }
+
+    // return value between 1, 2
+    private double calculateScore(List<Integer> list, int start, int size) {
+        int end = start + size;
+        double sum = 0.0;
+        for (int i = start; i < end; i++) {
+            sum += list.get(i) * weights[i];
+        }
+        return sum / size;
+    }
+}

--- a/src/main/java/org/withtime/be/withtimebe/global/error/code/DatePreferenceErrorCode.java
+++ b/src/main/java/org/withtime/be/withtimebe/global/error/code/DatePreferenceErrorCode.java
@@ -1,0 +1,25 @@
+package org.withtime.be.withtimebe.global.error.code;
+
+import lombok.AllArgsConstructor;
+import org.namul.api.payload.code.BaseErrorCode;
+import org.namul.api.payload.code.dto.supports.DefaultResponseErrorReasonDTO;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum DatePreferenceErrorCode implements BaseErrorCode {
+
+    INVALID_ANSWERS(HttpStatus.BAD_REQUEST, "DATE_PREFERENCE400_1", "질문에 대한 응답의 형식이 잘못되었습니다.")
+    ;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public DefaultResponseErrorReasonDTO getReason() {
+        return DefaultResponseErrorReasonDTO.builder()
+                .httpStatus(this.httpStatus)
+                .code(this.code)
+                .message(this.message)
+                .build();
+    }
+}

--- a/src/main/java/org/withtime/be/withtimebe/global/error/exception/DatePreferenceException.java
+++ b/src/main/java/org/withtime/be/withtimebe/global/error/exception/DatePreferenceException.java
@@ -1,0 +1,11 @@
+package org.withtime.be.withtimebe.global.error.exception;
+
+import org.namul.api.payload.code.BaseErrorCode;
+import org.namul.api.payload.error.exception.ServerApplicationException;
+
+public class DatePreferenceException extends ServerApplicationException {
+
+    public DatePreferenceException(BaseErrorCode code) {
+        super(code);
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #66 

## 📌 개요
- 데이트 취향 테스트 API 구현

## 🔁 변경 사항 
- 데이트 취향 테스트를 진행하고 결과를 DB에서 불러오고 DB에 저장하는 방식
  - 내용 변경이 서버 운영에 지장이 없도록 즉, 새롭게 배포를 하지 않아도 취향 테스트의 결과를 변경할 수 있도록 DB에서 유지.
  - DB에 저장은 로깅을 위해 저장하므로 `TestResultRepository`를 바로 JPA에 연결하는 것이 아닌 JPA를 하위 인터페이스를 만들어서 연결
    - 추후 로깅을 다른 곳에 할 경우 `TestResultRepository`의 구현체만 바꾸면 되도록 구현
- 데이트 취향 테스트를 진행하는 클래스를 구현하고 인터페이스로 추상화
  - 추후 취향 테스트의 방식이 변경될 경우를 대비해 인터페이스 및 구현체로 구현, 바뀌는 경우 구현체만 변경하는 경우 적용될 수 있도록
  - 현재는 가중치를 이용해 계산하는 방식으로 구현

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
