### PR TITLE
♻️ [REFACTOR] 레디스 캐싱을 통한 인기 키워드 조회 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
 
     // firebase
     implementation 'com.google.firebase:firebase-admin:9.1.0'
+
+    // jackson LocalDateTime 직렬화
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/withtime/be/withtimebe/WithTimeBeApplication.java
+++ b/src/main/java/org/withtime/be/withtimebe/WithTimeBeApplication.java
@@ -4,6 +4,7 @@ import java.util.TimeZone;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -13,6 +14,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import jakarta.annotation.PostConstruct;
 
 
+@EnableCaching
 @EnableScheduling
 @EnableJpaAuditing
 @EnableJpaRepositories(

--- a/src/main/java/org/withtime/be/withtimebe/domain/log/placecategorylog/scheduler/PlaceCategoryLogScheduler.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/log/placecategorylog/scheduler/PlaceCategoryLogScheduler.java
@@ -12,6 +12,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -36,7 +37,15 @@ public class PlaceCategoryLogScheduler {
 	private final PlaceCategoryRepository placeCategoryRepository;
 
 	@Scheduled(cron = "${scheduler.logs.place-category.sync-cron}") // 매 5분마다
+	@CacheEvict(
+		value = "place-category-log",
+		key = "'weekly:' + T(java.time.LocalDate).now().getYear() + '-' + T(java.time.temporal.WeekFields).ISO.weekOfYear().getFrom(T(java.time.LocalDate).now())",
+		cacheManager = "redisCacheManager",
+		beforeInvocation = false
+	)
 	public void syncPlaceCategoryLogsToDB() {
+
+		log.info("[PlaceCategoryLogScheduler] 동기화 스케쥴러 동작");
 
 		// 현재 날짜 및 레디스 키 생성
 		LocalDate now = LocalDate.from(LocalDateTime.now().minusMinutes(1));

--- a/src/main/java/org/withtime/be/withtimebe/domain/log/placecategorylog/service/query/PlaceCategoryLogQueryServiceImpl.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/log/placecategorylog/service/query/PlaceCategoryLogQueryServiceImpl.java
@@ -4,6 +4,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.withtime.be.withtimebe.domain.log.placecategorylog.model.PlaceCategoryLog;
@@ -19,6 +20,11 @@ public class PlaceCategoryLogQueryServiceImpl implements PlaceCategoryLogQuerySe
 	private final PlaceCategoryLogRepository placeCategoryLogRepository;
 
 	@Override
+	@Cacheable(
+		value = "place-category-log",
+		key = "'weekly:' + T(java.time.LocalDate).now().getYear() + '-' + T(java.time.temporal.WeekFields).ISO.weekOfYear().getFrom(T(java.time.LocalDate).now())",
+		cacheManager = "redisCacheManager"
+	)
 	public List<PlaceCategoryLog> findWeeklyPlaceCategoryLogList() {
 
 		LocalDate now = LocalDate.now();

--- a/src/main/java/org/withtime/be/withtimebe/global/config/MapperConfig.java
+++ b/src/main/java/org/withtime/be/withtimebe/global/config/MapperConfig.java
@@ -1,0 +1,28 @@
+package org.withtime.be.withtimebe.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class MapperConfig {
+
+	@Bean
+	public ObjectMapper objectMapper() {
+
+		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+			.allowIfSubType(Object.class)
+			.build();
+
+		return new ObjectMapper()
+			.enable(SerializationFeature.INDENT_OUTPUT)
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.registerModule(new JavaTimeModule())   // LocalDateTime 지원 모듈 추가
+			.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL);  // 클래스 정보를 포함하여 직렬/역직렬화 하도록 설정
+	}
+}

--- a/src/main/java/org/withtime/be/withtimebe/global/config/RedisConfig.java
+++ b/src/main/java/org/withtime/be/withtimebe/global/config/RedisConfig.java
@@ -1,19 +1,35 @@
 package org.withtime.be.withtimebe.global.config;
 
+import static org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair.*;
+
+import java.time.Duration;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.withtime.be.withtimebe.global.data.RedisConfigData;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
 @RequiredArgsConstructor
 public class RedisConfig {
 
     private final RedisConfigData redisConfigData;
+    private final ObjectMapper objectMapper;
 
     @Bean
     RedisConnectionFactory redisConnectionFactory() {
@@ -27,5 +43,16 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(RedisSerializer.string());
         redisTemplate.setValueSerializer(RedisSerializer.java());
         return  redisTemplate;
+    }
+
+    @Bean
+    public RedisCacheManager redisCacheManager() {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper)))
+            .entryTtl(Duration.ofDays(1L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory())
+            .cacheDefaults(redisCacheConfiguration).build();
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #77 

## 📌 개요
- 기존
   - 이번주 인기 키워드 조회는 항상 디스크 IO를 유발하여 응답 속도가 느림. 
   - 인기 키워드 갱신은 5분 단위로 이루어지므로 그 동안은 조회 데이터가 동일함 

- 개선 
  - 레디스 캐싱 설정
  - 스케쥴러로 DB에 갱신이 일어난 경우, 정합성 보장을 위해 캐시 무효화

## 🔁 변경 사항 

## 📸 스크린샷 (Optional)

### Before
<img width="362" height="380" alt="캐싱 미적용" src="https://github.com/user-attachments/assets/75158ec0-7985-4b5f-af83-528de93c83e6" />
<br>
 - 초당 작업 처리량 : 1919.3
 - 평균 응답 속도 : 49.49 ms


### After
<img width="352" height="389" alt="캐싱 적용" src="https://github.com/user-attachments/assets/721808e1-d28e-42b1-a491-2d1ecedf7015" />
<br>
 - 초당 작업 처리량 : 2955.2
 - 평균 응답 속도 : 33.26 ms

## 👀 기타 더 이야기해볼 점 (Optional)

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
