### PR TITLE
✨ [Feat] 로그인 사용자가 설정한 지역 조회 API, 사용자 지역 변경 API

### DIFF
--- a/src/main/java/org/withtime/be/withtimebe/domain/member/entity/Member.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/member/entity/Member.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.SQLRestriction;
 import org.withtime.be.withtimebe.domain.member.entity.enums.Gender;
 import org.withtime.be.withtimebe.domain.member.entity.enums.Role;
 import org.withtime.be.withtimebe.domain.member.entity.enums.UserRank;
+import org.withtime.be.withtimebe.domain.weather.entity.Region;
 import org.withtime.be.withtimebe.global.common.BaseEntity;
 
 import java.time.LocalDate;
@@ -75,6 +76,10 @@ public class Member extends BaseEntity {
     @Column(name = "role", nullable = false)
     private Role role;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private Region region;
+
     public void changeUsername(String newUsername) {
         this.username= newUsername;
     }
@@ -91,5 +96,9 @@ public class Member extends BaseEntity {
         this.pushAlarm = pushAlarm;
         this.emailAlarm = emailAlarm;
         this.smsAlarm = smsAlarm;
+    }
+
+    public void updateRegion(Region region) {
+        this.region = region;
     }
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/controller/RegionController.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/controller/RegionController.java
@@ -192,7 +192,7 @@ public class RegionController {
         return DefaultResponse.ok(response);
     }
 
-    @GetMapping("/user/current")
+    @GetMapping("/users/current")
     @Operation(summary = "현재 사용자 지역 조회 API by 지미",
             description = "로그인한 사용자의 현재 지역 정보를 조회합니다.")
     @ApiResponses(value = {
@@ -204,6 +204,28 @@ public class RegionController {
         log.info("현재 사용자 지역 조회 API 호출");
 
         RegionResDTO.UserRegion response = regionQueryService.getCurrentUserRegion(member);
+        return DefaultResponse.ok(response);
+    }
+
+    @PatchMapping("/users")
+    @Operation(summary = "사용자 지역 변경 API by 지미",
+            description = "로그인한 사용자의 지역을 설정/변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404",
+                    description = """
+                            다음과 같은 이유로 실패할 수 있습니다:
+                            - MEMBER404_0: 사용자를 찾을 수 없습니다.
+                            - WEATHER404_0: 지역을 찾을 수 없습니다.
+                            """)
+    })
+    public DefaultResponse<RegionResDTO.UserRegionWithMessage> updateUserRegion(
+            @Valid @RequestBody RegionReqDTO.UpdateUserRegion reqDTO, @AuthenticatedMember Member member) {
+        log.info("사용자 지역 변경 API 호출: regionId={}", reqDTO.regionId());
+
+        RegionResDTO.UserRegionWithMessage response = regionCommandService.updateUserRegion(reqDTO, member);
         return DefaultResponse.ok(response);
     }
 

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/controller/RegionController.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/controller/RegionController.java
@@ -11,10 +11,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.namul.api.payload.response.DefaultResponse;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.withtime.be.withtimebe.domain.member.entity.Member;
 import org.withtime.be.withtimebe.domain.weather.dto.request.RegionReqDTO;
 import org.withtime.be.withtimebe.domain.weather.dto.response.RegionResDTO;
 import org.withtime.be.withtimebe.domain.weather.service.command.RegionCommandService;
 import org.withtime.be.withtimebe.domain.weather.service.query.RegionQueryService;
+import org.withtime.be.withtimebe.global.security.annotation.AuthenticatedMember;
 
 @Slf4j
 @RestController
@@ -187,6 +189,21 @@ public class RegionController {
     public DefaultResponse<RegionResDTO.RegionSearchResult> searchRegions(
             @RequestParam String keyword) {
         RegionResDTO.RegionSearchResult response = regionQueryService.searchRegions(keyword);
+        return DefaultResponse.ok(response);
+    }
+
+    @GetMapping("/user/current")
+    @Operation(summary = "현재 사용자 지역 조회 API by 지미",
+            description = "로그인한 사용자의 현재 지역 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "사용자 또는 지역을 찾을 수 없습니다.")
+    })
+    public DefaultResponse<RegionResDTO.UserRegion> getCurrentUserRegion(@AuthenticatedMember Member member) {
+        log.info("현재 사용자 지역 조회 API 호출");
+
+        RegionResDTO.UserRegion response = regionQueryService.getCurrentUserRegion(member);
         return DefaultResponse.ok(response);
     }
 

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/controller/WeatherController.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/controller/WeatherController.java
@@ -72,7 +72,7 @@ public class WeatherController {
 
     @GetMapping("/{regionId}/weekly")
     @Operation(
-            summary = "지역별 주간 날씨 기반 추천 조회",
+            summary = "지역별 주간 날씨 기반 추천 조회 by 지미",
             description = """
         특정 지역의 7일치(오늘 기준) 날씨 데이터를 바탕으로 한 데이트 추천 정보를 제공합니다.
 
@@ -100,7 +100,7 @@ public class WeatherController {
 
     @GetMapping("/{regionId}/precipitation")
     @Operation(
-            summary = "지역별 7일간 강수확률 조회",
+            summary = "지역별 7일간 강수확률 조회 by 지미",
             description = """
     특정 지역의 7일간 강수확률 정보만 간단하게 조회합니다.
     

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/converter/RegionConverter.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/converter/RegionConverter.java
@@ -156,4 +156,16 @@ public class RegionConverter {
                 .message("지역이 성공적으로 삭제되었습니다.")
                 .build();
     }
+
+    public static RegionResDTO.UserRegion toUserRegion(Region region) {
+        return RegionResDTO.UserRegion.builder()
+                .regionId(region.getId())
+                .name(region.getName())
+                .latitude(region.getLatitude())
+                .longitude(region.getLongitude())
+                .gridX(region.getGridX())
+                .gridY(region.getGridY())
+                .regionCode(toRegionCodeInfo(region.getRegionCode()))
+                .build();
+    }
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/converter/RegionConverter.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/converter/RegionConverter.java
@@ -168,4 +168,13 @@ public class RegionConverter {
                 .regionCode(toRegionCodeInfo(region.getRegionCode()))
                 .build();
     }
+
+    public static RegionResDTO.UserRegionWithMessage toUserRegionWithMessage(Region region, String message) {
+        return RegionResDTO.UserRegionWithMessage.builder()
+                .regionId(region.getId())
+                .name(region.getName())
+                .regionCode(toRegionCodeInfo(region.getRegionCode()))
+                .message(message)
+                .build();
+    }
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/dto/request/RegionReqDTO.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/dto/request/RegionReqDTO.java
@@ -56,4 +56,10 @@ public class RegionReqDTO {
             String regionCodeName
     ) {
     }
+
+    public record UpdateUserRegion(
+            @NotNull(message = "지역 ID는 필수 입력값입니다.")
+            Long regionId
+    ) {
+    }
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/dto/response/RegionResDTO.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/dto/response/RegionResDTO.java
@@ -115,4 +115,13 @@ public class RegionResDTO {
             RegionCodeInfo regionCode
     ) {
     }
+
+    @Builder
+    public record UserRegionWithMessage(
+            Long regionId,
+            String name,
+            RegionCodeInfo regionCode,
+            String message
+    ) {
+    }
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/dto/response/RegionResDTO.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/dto/response/RegionResDTO.java
@@ -103,4 +103,16 @@ public class RegionResDTO {
             String message
     ) {
     }
+
+    @Builder
+    public record UserRegion(
+            Long regionId,
+            String name,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BigDecimal gridX,
+            BigDecimal gridY,
+            RegionCodeInfo regionCode
+    ) {
+    }
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/service/command/RegionCommandService.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/service/command/RegionCommandService.java
@@ -1,5 +1,6 @@
 package org.withtime.be.withtimebe.domain.weather.service.command;
 
+import org.withtime.be.withtimebe.domain.member.entity.Member;
 import org.withtime.be.withtimebe.domain.weather.dto.request.RegionReqDTO;
 import org.withtime.be.withtimebe.domain.weather.dto.response.RegionResDTO;
 
@@ -14,4 +15,6 @@ public interface RegionCommandService {
     RegionResDTO.DeleteRegionCode deleteRegionCode(Long regionCodeId);
 
     RegionResDTO.DeleteRegion deleteRegion(Long regionId);
+
+    RegionResDTO.UserRegionWithMessage updateUserRegion(RegionReqDTO.UpdateUserRegion reqDTO, Member member);
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/service/command/RegionCommandServiceImpl.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/service/command/RegionCommandServiceImpl.java
@@ -4,7 +4,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.withtime.be.withtimebe.domain.member.entity.Member;
+import org.withtime.be.withtimebe.domain.member.repository.MemberRepository;
 import org.withtime.be.withtimebe.domain.weather.converter.RegionConverter;
 import org.withtime.be.withtimebe.domain.weather.dto.request.RegionReqDTO;
 import org.withtime.be.withtimebe.domain.weather.dto.response.RegionResDTO;
@@ -12,7 +15,11 @@ import org.withtime.be.withtimebe.domain.weather.entity.Region;
 import org.withtime.be.withtimebe.domain.weather.entity.RegionCode;
 import org.withtime.be.withtimebe.domain.weather.repository.RegionCodeRepository;
 import org.withtime.be.withtimebe.domain.weather.repository.RegionRepository;
+import org.withtime.be.withtimebe.global.error.code.MemberErrorCode;
+import org.withtime.be.withtimebe.global.error.code.RegionErrorCode;
 import org.withtime.be.withtimebe.global.error.code.WeatherErrorCode;
+import org.withtime.be.withtimebe.global.error.exception.MemberException;
+import org.withtime.be.withtimebe.global.error.exception.RegionException;
 import org.withtime.be.withtimebe.global.error.exception.WeatherException;
 
 import java.math.BigDecimal;
@@ -29,6 +36,7 @@ public class RegionCommandServiceImpl implements RegionCommandService {
 
     private final RegionRepository regionRepository;
     private final RegionCodeRepository regionCodeRepository;
+    private final MemberRepository memberRepository;
 
     @Value("${weather.api.key}")
     private String apiKey;
@@ -126,6 +134,21 @@ public class RegionCommandServiceImpl implements RegionCommandService {
         regionRepository.delete(region);
 
         return RegionConverter.toDeleteRegion(region);
+    }
+
+    @Override
+    @Transactional
+    public RegionResDTO.UserRegionWithMessage updateUserRegion(RegionReqDTO.UpdateUserRegion reqDTO, Member member) {
+        Member currentMember = memberRepository.findByEmail(member.getEmail())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        Region region = regionRepository.findByIdWithRegionCode(reqDTO.regionId())
+                .orElseThrow(() -> new RegionException(RegionErrorCode.REGION_NOT_FOUND));
+
+        currentMember.updateRegion(region);
+
+        String message = "지역이 성공적으로 변경되었습니다.";
+        return RegionConverter.toUserRegionWithMessage(region, message);
     }
 
     // ==== 내부 유틸리티 메서드들 ====

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/service/query/RegionQueryService.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/service/query/RegionQueryService.java
@@ -1,5 +1,6 @@
 package org.withtime.be.withtimebe.domain.weather.service.query;
 
+import org.withtime.be.withtimebe.domain.member.entity.Member;
 import org.withtime.be.withtimebe.domain.weather.dto.response.RegionResDTO;
 
 public interface RegionQueryService {
@@ -11,4 +12,6 @@ public interface RegionQueryService {
     RegionResDTO.RegionInfo getRegionById(Long regionId);
 
     RegionResDTO.RegionSearchResult searchRegions(String keyword);
+
+    RegionResDTO.UserRegion getCurrentUserRegion(Member member);
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/weather/service/query/RegionQueryServiceImpl.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/weather/service/query/RegionQueryServiceImpl.java
@@ -3,12 +3,19 @@ package org.withtime.be.withtimebe.domain.weather.service.query;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.withtime.be.withtimebe.domain.member.entity.Member;
+import org.withtime.be.withtimebe.domain.member.repository.MemberRepository;
 import org.withtime.be.withtimebe.domain.weather.converter.RegionConverter;
 import org.withtime.be.withtimebe.domain.weather.dto.response.RegionResDTO;
 import org.withtime.be.withtimebe.domain.weather.entity.Region;
 import org.withtime.be.withtimebe.domain.weather.repository.RegionCodeRepository;
 import org.withtime.be.withtimebe.domain.weather.repository.RegionRepository;
+import org.withtime.be.withtimebe.global.error.code.MemberErrorCode;
+import org.withtime.be.withtimebe.global.error.code.RegionErrorCode;
 import org.withtime.be.withtimebe.global.error.code.WeatherErrorCode;
+import org.withtime.be.withtimebe.global.error.exception.MemberException;
+import org.withtime.be.withtimebe.global.error.exception.RegionException;
 import org.withtime.be.withtimebe.global.error.exception.WeatherException;
 
 import java.util.List;
@@ -20,6 +27,9 @@ public class RegionQueryServiceImpl implements RegionQueryService{
 
     private final RegionCodeRepository regionCodeRepository;
     private final RegionRepository regionRepository;
+    private final MemberRepository memberRepository;
+
+    private static final Long DEFAULT_REGION_ID = 1L;
 
     @Override
     public RegionResDTO.RegionCodeList getAllRegionCodes() {
@@ -44,5 +54,29 @@ public class RegionQueryServiceImpl implements RegionQueryService{
     public RegionResDTO.RegionSearchResult searchRegions(String keyword) {
         List<Region> regions = regionRepository.searchByNameContaining(keyword);
         return RegionConverter.toSearchResult(regions, keyword);
+    }
+
+    @Override
+    @Transactional
+    public RegionResDTO.UserRegion getCurrentUserRegion(Member member) {
+        // 현재 로그인한 사용자 조회
+        Member currentMember = memberRepository.findByEmail(member.getEmail())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        Region userRegion = currentMember.getRegion();
+
+        // 사용자에게 지역이 설정되지 않은 경우 기본 지역 반환
+        if (userRegion == null) {
+            userRegion = regionRepository.findByIdWithRegionCode(DEFAULT_REGION_ID)
+                    .orElseThrow(() -> new RegionException(RegionErrorCode.REGION_NOT_FOUND));
+
+            currentMember.updateRegion(userRegion);
+            memberRepository.save(currentMember);
+
+            log.info("사용자 {}에게 기본 지역({})이 자동 설정되었습니다.",
+                    currentMember.getUsername(), userRegion.getName());
+        }
+
+        return RegionConverter.toUserRegion(userRegion);
     }
 }

--- a/src/main/java/org/withtime/be/withtimebe/global/error/code/RegionErrorCode.java
+++ b/src/main/java/org/withtime/be/withtimebe/global/error/code/RegionErrorCode.java
@@ -1,0 +1,28 @@
+package org.withtime.be.withtimebe.global.error.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.namul.api.payload.code.BaseErrorCode;
+import org.namul.api.payload.code.dto.supports.DefaultResponseErrorReasonDTO;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum RegionErrorCode implements BaseErrorCode {
+
+    // ==== 지역 관련 에러 (404) ====
+    REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION404_0", "지역을 찾을 수 없습니다."),
+    ;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public DefaultResponseErrorReasonDTO getReason() {
+        return DefaultResponseErrorReasonDTO.builder()
+                .httpStatus(this.httpStatus)
+                .code(this.code)
+                .message(this.message)
+                .build();
+    }
+}

--- a/src/main/java/org/withtime/be/withtimebe/global/error/exception/RegionException.java
+++ b/src/main/java/org/withtime/be/withtimebe/global/error/exception/RegionException.java
@@ -1,0 +1,10 @@
+package org.withtime.be.withtimebe.global.error.exception;
+
+import org.namul.api.payload.code.BaseErrorCode;
+import org.namul.api.payload.error.exception.ServerApplicationException;
+
+public class RegionException extends ServerApplicationException {
+    public RegionException(BaseErrorCode baseErrorCode)  {
+        super(baseErrorCode);
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #80 

## 📌 개요
- 로그인 사용자가 설정한 지역 조회 API 개발
- 사용자 지역 변경 API 개발

## 🔁 변경 사항 
Member N : 1 Region 연관관계 걸었습니다.

## 📸 스크린샷 (Optional)

### 로그인 사용자가 설정한 지역 조회 API
<img width="583" height="492" alt="image" src="https://github.com/user-attachments/assets/d9382cde-da2e-4516-b46e-3ddcfbf692dc" />

- 처음 회원가입 시 DB에서 User에 연결되어있는 region_id 필드가 NULL로 들어가게 됩니다.
- 그래서 NULL일 경우에 해당 API를 호출 시, 자동으로 region_id가 1(인사동)로 update되게 설계했습니다.

### 사용자 지역 변경 API 개발
<img width="509" height="445" alt="image" src="https://github.com/user-attachments/assets/b9499300-93c3-433a-ac26-cb80e113b156" />


## 👀 기타 더 이야기해볼 점 (Optional)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
