### PR TITLE
🐛 [FIX] 몽고 Between 조회 시, 양 끝 범위를 포함하도록 수정

### DIFF
--- a/src/main/java/org/withtime/be/withtimebe/domain/log/placecategorylog/repository/PlaceCategoryLogRepository.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/log/placecategorylog/repository/PlaceCategoryLogRepository.java
@@ -4,9 +4,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.withtime.be.withtimebe.domain.log.placecategorylog.model.PlaceCategoryLog;
 
 public interface PlaceCategoryLogRepository extends MongoRepository<PlaceCategoryLog, String> {
+	@Query("{ 'date': { $gte: ?0, $lte: ?1 } }")
 	List<PlaceCategoryLog> findByDateBetween(LocalDate startDate, LocalDate endDate);
 	List<PlaceCategoryLog> findByDateAndPlaceCategoryLabelIn(LocalDate date, List<String> placeCategoryLabel);
 }

--- a/src/main/java/org/withtime/be/withtimebe/domain/log/placecategorylog/scheduler/PlaceCategoryLogScheduler.java
+++ b/src/main/java/org/withtime/be/withtimebe/domain/log/placecategorylog/scheduler/PlaceCategoryLogScheduler.java
@@ -42,7 +42,6 @@ public class PlaceCategoryLogScheduler {
 		cacheManager = "redisCacheManager",
 		beforeInvocation = false
 	)
-	@Scheduled(cron = "${scheduler.logs.place-category.sync-cron}") // 매 5분마다
 	public void syncUserPreferredKeywordsToDB() {
 
 		log.info("[PlaceCategoryLogScheduler] 동기화 스케쥴러 동작");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -146,7 +146,7 @@ scheduler:
   logs:
     place-category:
       enabled: true
-      sync-cron: "0 */5 * * * *"  # 5분마다 Redis -> Mongo 동기화
+      sync-cron: "0 */3 * * * *"  # 5분마다 Redis -> Mongo 동기화
     date-place:
       enabled: true
       sync-cron: "0 0 0 * * *"  # 매일 자정마다 동기화


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #117 

## 📌 개요
- 몽고 리포지토리의 Between 키워드로 쿼리를 자동 생성 하는 경우, 양 끝 범위를 포함하지 않아 조회가 되지 않는 문제가 존재하였습니다.

## 🔁 변경 사항 
- 직접 @Query로 포함하도록 변경
- 인기 키워드의 동기화 스케쥴링을 5->3분으로 수정

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
